### PR TITLE
Add option to export with texture file references included

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,10 @@ var result = exporter.parse(scene);
 ```
 
 See [the offical Three.js example](http://threejs.org/examples/webgl_exporter_obj.html) for more information and usage.
+
+## Options
+
+To include a reference to MTL texture files for an object, pass this option:
+```
+var result = exporter.parse(scene, { includeMaterials: true });
+```

--- a/index.js
+++ b/index.js
@@ -76,10 +76,10 @@ OBJExporter.prototype = {
                        vertex.applyMatrix4( mesh.matrixWorld );
 
                        // don't add any vertices that are messed up "NaN"
-                       const hasNaNValues = Object.values(vertex).filter(pos => pos === "NaN");
+                       const hasNaNValues = Object.values(vertex).some(pos => isNaN(pos));
                        
                        if (hasNaNValues) {
-                           console.error("Found bad vertex value", vertex);
+                            console.log("found NaN vertex", vertex);
                        } else {
                             // transform the vertex to export format
                             output += 'v ' + vertex.x + ' ' + vertex.y + ' ' + vertex.z + '\n';
@@ -118,12 +118,13 @@ OBJExporter.prototype = {
 
                        // transfrom the normal to world space
                        normal.applyMatrix3( normalMatrixWorld );
-                        
+                       
                        // don't add any normals that are messed up "NaN"
-                       const hasNaNValues = Object.values(normal).filter(pos => pos === "NaN");
+                       const hasNaNValues = Object.values(normal).some(pos => isNaN(pos));
                        
                        if (hasNaNValues) {
-                           console.error("Found bad normal value", normal);
+                            // do not add
+                            console.log("found NaN normal", normal);
                        } else {
                           // transform the vertex to export format
                           output += 'vn ' + normal.x + ' ' + normal.y + ' ' + normal.z + '\n';

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var THREE = require( 'three' );
 
 /**
 * @author mrdoob / http://mrdoob.com/
+*   fixed by Sam
 */
 
 function OBJExporter () {};
@@ -74,9 +75,15 @@ OBJExporter.prototype = {
                        // transfrom the vertex to world space
                        vertex.applyMatrix4( mesh.matrixWorld );
 
-                       // transform the vertex to export format
-                       output += 'v ' + vertex.x + ' ' + vertex.y + ' ' + vertex.z + '\n';
-
+                       // don't add any vertices that are messed up "NaN"
+                       const hasNaNValues = Object.values(vertex).filter(pos => pos === "NaN");
+                       
+                       if (hasNaNValues) {
+                           console.error("Found bad vertex value", vertex);
+                       } else {
+                            // transform the vertex to export format
+                            output += 'v ' + vertex.x + ' ' + vertex.y + ' ' + vertex.z + '\n';
+                       }
                    }
 
                }

--- a/index.js
+++ b/index.js
@@ -118,10 +118,16 @@ OBJExporter.prototype = {
 
                        // transfrom the normal to world space
                        normal.applyMatrix3( normalMatrixWorld );
-
-                       // transform the normal to export format
-                       output += 'vn ' + normal.x + ' ' + normal.y + ' ' + normal.z + '\n';
-
+                        
+                       // don't add any normals that are messed up "NaN"
+                       const hasNaNValues = Object.values(normal).filter(pos => pos === "NaN");
+                       
+                       if (hasNaNValues) {
+                           console.error("Found bad normal value", normal);
+                       } else {
+                          // transform the vertex to export format
+                          output += 'vn ' + normal.x + ' ' + normal.y + ' ' + normal.z + '\n';
+                       }
                    }
 
                }

--- a/index.js
+++ b/index.js
@@ -9,8 +9,11 @@ function OBJExporter () {};
 OBJExporter.prototype = {
 
    constructor: OBJExporter,
-
-   parse: function ( object ) {
+   
+   // options: {
+   //   includeMaterials: boolean, // exports with pointer to material file
+   // }
+   parse: function ( object, options ) {
 
        var output = '';
 
@@ -50,7 +53,14 @@ OBJExporter.prototype = {
 
                // name of the mesh object
                output += 'o ' + mesh.name + '\n';
-
+              
+               if (options.includeMaterials) {
+                  
+                   // include texture file
+                   output += 'usemtl ' + mesh.name + '\n';
+                  
+               }
+              
                // vertices
 
                if( vertices !== undefined ) {


### PR DESCRIPTION
Thank you for making this library!

I have been exporting OBJ files that have references to MTL texture files. Without this feature, those textures are not copied out during export.

Currently:
```
o Mesh_name
```

Example with materials reference:
```
o Mesh_name
usemtl Mesh_name
```
